### PR TITLE
AddOrReplace Fix

### DIFF
--- a/src/Codeworx.Rest.Client/Extensions/CodeworxRestClientServiceCollectionExtensions.cs
+++ b/src/Codeworx.Rest.Client/Extensions/CodeworxRestClientServiceCollectionExtensions.cs
@@ -21,7 +21,7 @@ namespace Microsoft.Extensions.DependencyInjection
             where TContract : class
             where TImplementation : TContract
         {
-            var found = services.FirstOrDefault(p => p.ServiceType == typeof(TContract) && (p.ImplementationType ?? p.ImplementationFactory?.Method.ReturnType) == typeof(TImplementation) && p.Lifetime == lifetime);
+            var found = services.FirstOrDefault(p => p.ServiceType == typeof(TContract) && (p.ImplementationType ?? p.ImplementationFactory?.Method?.ReturnType) == typeof(TImplementation) && p.Lifetime == lifetime);
 
             var service = ServiceDescriptor.Describe(typeof(TContract), factory, lifetime);
 

--- a/src/Codeworx.Rest.Client/Extensions/CodeworxRestClientServiceCollectionExtensions.cs
+++ b/src/Codeworx.Rest.Client/Extensions/CodeworxRestClientServiceCollectionExtensions.cs
@@ -21,7 +21,7 @@ namespace Microsoft.Extensions.DependencyInjection
             where TContract : class
             where TImplementation : TContract
         {
-            var found = services.FirstOrDefault(p => p.ServiceType == typeof(TContract) && p.ImplementationType == typeof(TImplementation) && p.Lifetime == lifetime);
+            var found = services.FirstOrDefault(p => p.ServiceType == typeof(TContract) && (p.ImplementationType ?? p.ImplementationFactory?.Method.ReturnType) == typeof(TImplementation) && p.Lifetime == lifetime);
 
             var service = ServiceDescriptor.Describe(typeof(TContract), factory, lifetime);
 

--- a/test/Codeworx.Rest.IntegrationTests/RestOptionsBuilderTest.cs
+++ b/test/Codeworx.Rest.IntegrationTests/RestOptionsBuilderTest.cs
@@ -6,6 +6,7 @@ using System.Net.Http;
 using System.Reflection;
 using System.Threading.Tasks;
 using Codeworx.Rest.Client;
+using Codeworx.Rest.Client.Formatters;
 using Codeworx.Rest.UnitTests.Api.Contract;
 using Codeworx.Rest.UnitTests.Data;
 using Codeworx.Rest.UnitTests.Generated;
@@ -58,6 +59,20 @@ namespace Codeworx.Rest.UnitTests
 
             var options = provider.GetRequiredService<RestOptions<IPathService>>();
             Assert.Equal(new Uri("http://localhost:1234/testurl"), options.GetHttpClient().BaseAddress);
+        }
+
+        [Fact]
+        public void AddOrReplaceServiceTest()
+        {
+            var services = new ServiceCollection();
+            services.AddSingleton<IContentFormatter, JsonContentFormatter>(sp => null);
+            services.AddOrReplace<IContentFormatter, JsonContentFormatter>(ServiceLifetime.Singleton, sp => new JsonContentFormatter(new Newtonsoft.Json.JsonSerializerSettings()));
+
+            var provider = services.BuildServiceProvider();
+
+            var jsonFormatter = provider.GetRequiredService<IEnumerable<IContentFormatter>>();
+            Assert.Single(jsonFormatter);
+            Assert.NotNull(jsonFormatter.First());
         }
     }
 }


### PR DESCRIPTION
Beim Ändern der JsonOptions sind 2 JsonContentFormatter's im DI vorhanden, trotz AddOrReplace.